### PR TITLE
Manager thread

### DIFF
--- a/Bonsai.ONIX.Design/Bonsai.ONIX.Design.csproj
+++ b/Bonsai.ONIX.Design/Bonsai.ONIX.Design.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="clroni" Version="4.3.2" />
+    <PackageReference Include="clroni" Version="4.3.3" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <PackageReference Include="TinyCsvParser" Version="2.6.0" />
   </ItemGroup>

--- a/Bonsai.ONIX/BNO055DataFrame.cs
+++ b/Bonsai.ONIX/BNO055DataFrame.cs
@@ -5,9 +5,10 @@ namespace Bonsai.ONIX
 {
     public class BNO055DataFrame : DataFrame
     {
-        public BNO055DataFrame(oni.Frame frame)
+        public BNO055DataFrame(RawDataFrame<ushort> frame)
             : base(frame)
         {
+            ushort[] sample = frame.sample;
             // Convert data packet (output format is hard coded right now)
             Euler = GetEuler(sample, 4);
             Quaternion = GetQuat(sample, 7);

--- a/Bonsai.ONIX/BNO055Device.cs
+++ b/Bonsai.ONIX/BNO055Device.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("BNO055 inertial measurement unit.")]
-    public class BNO055Device : ONIFrameReader<BNO055DataFrame>
+    public class BNO055Device : ONIFrameReader<BNO055DataFrame, ushort>
     {
         enum Register
         {
@@ -16,7 +16,7 @@ namespace Bonsai.ONIX
 
         public BNO055Device() : base(ONIXDevices.ID.BNO055) { }
 
-        protected override IObservable<BNO055DataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<BNO055DataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new BNO055DataFrame(f); });
         }

--- a/Bonsai.ONIX/Bonsai.ONIX.csproj
+++ b/Bonsai.ONIX/Bonsai.ONIX.csproj
@@ -72,7 +72,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.6.0" />
-    <PackageReference Include="clroni" Version="4.3.2" />
+    <PackageReference Include="clroni" Version="4.3.3" />
     <PackageReference Include="OpenCV.Net" Version="3.3.1" />
   </ItemGroup>
 

--- a/Bonsai.ONIX/BreakoutDigitalInputDataFrame.cs
+++ b/Bonsai.ONIX/BreakoutDigitalInputDataFrame.cs
@@ -2,12 +2,12 @@
 {
     public class BreakoutDigitalInputDataFrame : DataFrame
     {
-        public BreakoutDigitalInputDataFrame(oni.Frame frame)
+        public BreakoutDigitalInputDataFrame(RawDataFrame<ushort> frame)
             : base(frame)
         {
-            Port = sample[4];
-            Buttons = (byte)(0x00FF & sample[5]);
-            Links = (byte)((0x0F00 & sample[5]) >> 8);
+            Port = frame.sample[4];
+            Buttons = (byte)(0x00FF & frame.sample[5]);
+            Links = (byte)((0x0F00 & frame.sample[5]) >> 8);
         }
 
         public byte Buttons { get; private set; }

--- a/Bonsai.ONIX/BreakoutDigitalInputDevice.cs
+++ b/Bonsai.ONIX/BreakoutDigitalInputDevice.cs
@@ -7,7 +7,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Acquires digital data from an Open-Ephys FMC Breakout Board.")]
-    public class BreakoutDigitalInputDevice : ONIFrameReader<BreakoutDigitalInputDataFrame>
+    public class BreakoutDigitalInputDevice : ONIFrameReader<BreakoutDigitalInputDataFrame, ushort>
     {
         enum Register
         {
@@ -18,7 +18,7 @@ namespace Bonsai.ONIX
 
         public BreakoutDigitalInputDevice() : base(ONIXDevices.ID.BREAKDIG1R3) { }
 
-        protected override IObservable<BreakoutDigitalInputDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<BreakoutDigitalInputDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new BreakoutDigitalInputDataFrame(f); });
         }

--- a/Bonsai.ONIX/DataBlock.cs
+++ b/Bonsai.ONIX/DataBlock.cs
@@ -20,16 +20,16 @@ namespace Bonsai.ONIX
 
         protected abstract void FillFromData(ushort[] data);
 
-        public bool FillFromFrame(oni.Frame frame)
+        public bool FillFromFrame(RawDataFrame<ushort> frame)
         {
             if (index >= SamplesPerBlock)
             {
                 throw new IndexOutOfRangeException();
             }
 
-            var data = frame.Data<ushort>();
+            ushort[] data = frame.sample;
 
-            frame_clock[index] = frame.Clock;
+            frame_clock[index] = frame.FrameClock;
             data_clock[index] = ((ulong)data[0] << 48) | ((ulong)data[1] << 32) | ((ulong)data[2] << 16) | ((ulong)data[3] << 0);
 
             FillFromData(data);

--- a/Bonsai.ONIX/DataFrame.cs
+++ b/Bonsai.ONIX/DataFrame.cs
@@ -1,19 +1,27 @@
 ﻿namespace Bonsai.ONIX
 {
-    public class DataFrame
+    /// <summary>
+    /// Base class for most data frames using <see cref="ushort"/> as
+    /// the underlying data type.
+    /// </summary>
+    public class DataFrame 
     {
-        public DataFrame(oni.Frame frame)
+        public DataFrame(RawDataFrame<ushort> frame) 
         {
-            sample = frame.Data<ushort>();
 
-            FrameClock = frame.Clock;
-            DataClock = ((ulong)sample[0] << 48) | ((ulong)sample[1] << 32) | ((ulong)sample[2] << 16) | ((ulong)sample[3] << 0);
+            DataClock = ((ulong)frame.sample[0] << 48) | ((ulong)frame.sample[1] << 32) | ((ulong)frame.sample[2] << 16) | ((ulong)frame.sample[3] << 0);
+            
+            FrameClock = frame.FrameClock;
         }
 
-        protected ushort[] sample;
-
-        public ulong FrameClock { get; private set; }
+        /// <summary>
+        /// The sample clock, create locally alongside the source device.
+        /// </summary>
         public ulong DataClock { get; private set; }
+        /// <summary>
+        /// The frame clock. Created by the host when receiving the sample from the device.
+        /// </summary>
+        public ulong FrameClock { get; private set; }
 
     }
 }

--- a/Bonsai.ONIX/FMCAnalogIODevice.cs
+++ b/Bonsai.ONIX/FMCAnalogIODevice.cs
@@ -9,7 +9,7 @@ namespace Bonsai.ONIX
     [Description("Acquires data from the twelve 14-bit analog inputs on the Open Ephys FMC Host. " +
         "Optionally, sends data to the 16-bit analog outputs on the Open Ephys FMC Host, if those " +
         "channels are selected to be outputs.")]
-    public class FMCAnalogIODevice : ONIFrameReaderAndWriter<Arr, AnalogInputDataFrame>
+    public class FMCAnalogIODevice : ONIFrameReaderAndWriter<Arr, AnalogInputDataFrame, ushort>
     {
         const int NUM_CHANNELS = 12;
 
@@ -75,7 +75,7 @@ namespace Bonsai.ONIX
             //Enable = true;
         }
 
-        protected override IObservable<AnalogInputDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<AnalogInputDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             var data_block = new AnalogInputDataBlock(NUM_CHANNELS, BlockSize);
 

--- a/Bonsai.ONIX/FMCHeadstageControlDevice.cs
+++ b/Bonsai.ONIX/FMCHeadstageControlDevice.cs
@@ -7,7 +7,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Controls a SERDES link to a remote headstage on the Open Ephys FMC Host. THIS NODE CAN DAMAGE YOUR HEADSTAGE!")]
-    public class FMCHeadstageControlDevice : ONIFrameReader<FMCHeadstageControlFrame>
+    public class FMCHeadstageControlDevice : ONIFrameReader<FMCHeadstageControlFrame, ushort>
     {
         const double VLIM = 7.0;
 
@@ -23,7 +23,7 @@ namespace Bonsai.ONIX
 
         public FMCHeadstageControlDevice() : base(ONIXDevices.ID.FMCLINKCTRL) { }
 
-        protected override IObservable<FMCHeadstageControlFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<FMCHeadstageControlFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new FMCHeadstageControlFrame(f); });
         }

--- a/Bonsai.ONIX/FMCHeadstageControlFrame.cs
+++ b/Bonsai.ONIX/FMCHeadstageControlFrame.cs
@@ -3,12 +3,12 @@ namespace Bonsai.ONIX
 {
     public class FMCHeadstageControlFrame : DataFrame
     {
-        public FMCHeadstageControlFrame(oni.Frame frame)
+        public FMCHeadstageControlFrame(RawDataFrame<ushort> frame)
             : base(frame)
         {
-            Lock = (sample[4] & 0x0001) == 1;
-            Pass = (sample[4] & 0x0002) == 2;
-            Code = (sample[4] & 0x0004) == 4 ? (sample[4] & 0xFF00) >> 8 : 0;
+            Lock = (frame.sample[4] & 0x0001) == 1;
+            Pass = (frame.sample[4] & 0x0002) == 2;
+            Code = (frame.sample[4] & 0x0004) == 4 ? (frame.sample[4] & 0xFF00) >> 8 : 0;
         }
 
         public bool Lock { get; private set; }

--- a/Bonsai.ONIX/HeartbeatDevice.cs
+++ b/Bonsai.ONIX/HeartbeatDevice.cs
@@ -8,7 +8,7 @@ namespace Bonsai.ONIX
     using HeartbeatDataFrame = DataFrame;
 
     [Description("Heartbeat device")]
-    public class HeartbeatDevice : ONIFrameReader<HeartbeatDataFrame>
+    public class HeartbeatDevice : ONIFrameReader<HeartbeatDataFrame, ushort>
     {
         enum Register
         {
@@ -19,7 +19,7 @@ namespace Bonsai.ONIX
 
         public HeartbeatDevice() : base(ONIXDevices.ID.HEARTBEAT) { }
 
-        protected override IObservable<HeartbeatDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<HeartbeatDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new HeartbeatDataFrame(f); });
         }

--- a/Bonsai.ONIX/LoadTestingDataFrame.cs
+++ b/Bonsai.ONIX/LoadTestingDataFrame.cs
@@ -5,11 +5,11 @@ namespace Bonsai.ONIX
 {
     public class LoadTestingDataFrame : DataFrame
     {
-        public LoadTestingDataFrame(oni.Frame frame)
+        public LoadTestingDataFrame(RawDataFrame<ushort> frame)
             : base(frame)
         {
-            var data = new ushort[sample.Length - 4];
-            Array.Copy(sample, 4, data, 0, data.Length);
+            var data = new ushort[frame.sample.Length - 4];
+            Array.Copy(frame.sample, 4, data, 0, data.Length);
             Payload = Mat.FromArray(data, data.Length, 1, Depth.U16, 1);
         }
 

--- a/Bonsai.ONIX/LoadTestingDevice.cs
+++ b/Bonsai.ONIX/LoadTestingDevice.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Variable load testing device")]
-    public class LoadTestingDevice : ONIFrameReader<LoadTestingDataFrame>
+    public class LoadTestingDevice : ONIFrameReader<LoadTestingDataFrame, ushort>
     {
         enum Register
         {
@@ -20,7 +20,7 @@ namespace Bonsai.ONIX
 
         public LoadTestingDevice() : base(ONIXDevices.ID.LOADTEST) { }
 
-        protected override IObservable<LoadTestingDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<LoadTestingDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new LoadTestingDataFrame(f); });
         }

--- a/Bonsai.ONIX/MemoryUsageDataFrame.cs
+++ b/Bonsai.ONIX/MemoryUsageDataFrame.cs
@@ -2,10 +2,10 @@
 {
     public class MemoryUsageDataFrame : DataFrame
     {
-        public MemoryUsageDataFrame(oni.Frame frame, uint total_words)
+        public MemoryUsageDataFrame(RawDataFrame<ushort> frame, uint total_words)
             : base(frame)
         {
-            uint words = ((uint)sample[4] << 16) | ((uint)sample[5] << 0);
+            uint words = ((uint)frame.sample[4] << 16) | ((uint)frame.sample[5] << 0);
             MemoryUsagePercentage = 100.0 * words / total_words;
             MemoryUsageBytes = words * sizeof(uint);
         }

--- a/Bonsai.ONIX/MemoryUsageDevice.cs
+++ b/Bonsai.ONIX/MemoryUsageDevice.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Memory usage monitoring device")]
-    public class MemoryUsageDevice : ONIFrameReader<MemoryUsageDataFrame>
+    public class MemoryUsageDevice : ONIFrameReader<MemoryUsageDataFrame, ushort>
     {
         enum Register
         {
@@ -18,7 +18,7 @@ namespace Bonsai.ONIX
 
         public MemoryUsageDevice() : base(ONIXDevices.ID.MEMUSAGE) { }
 
-        protected override IObservable<MemoryUsageDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<MemoryUsageDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             var total_words = MemorySize;
             return source.Select(f => { return new MemoryUsageDataFrame(f, total_words); });

--- a/Bonsai.ONIX/NeuropixelsV1DataBlock.cs
+++ b/Bonsai.ONIX/NeuropixelsV1DataBlock.cs
@@ -62,12 +62,12 @@ namespace Bonsai.ONIX
         }
 
         // frame contains a single super frame
-        public bool FillFromFrame(oni.Frame frame)
+        public bool FillFromFrame(RawDataFrame<ushort> frame)
         {
 
-            var data = frame.Data<ushort>();
+            var data = frame.sample;
 
-            spike_frame_clock[super_cnt] = frame.Clock;
+            spike_frame_clock[super_cnt] = frame.FrameClock;
             spike_data_clock[super_cnt] = ((ulong)data[0] << 48) | ((ulong)data[1] << 32) | ((ulong)data[2] << 16) | ((ulong)data[3] << 0);
 
             for (int i = 0; i < FRAMES_PER_SUPER; i++)
@@ -80,7 +80,7 @@ namespace Bonsai.ONIX
                     var super_cnt_circ = super_cnt % SUPERS_PER_ULTRA;
                     if (super_cnt_circ == 0) // Use the first superframe in ultraframe as time of this lfp-data round robin
                     {
-                        lfp_frame_clock[ultra_cnt] = frame.Clock;
+                        lfp_frame_clock[ultra_cnt] = frame.FrameClock;
                         lfp_data_clock[ultra_cnt] = spike_data_clock[super_cnt];
                     }
 

--- a/Bonsai.ONIX/NeuropixelsV1Device.cs
+++ b/Bonsai.ONIX/NeuropixelsV1Device.cs
@@ -9,7 +9,7 @@ namespace Bonsai.ONIX
 {
     [Description("Acquires a stream of \"ultra-frames\" from a single Neuropixels v1.0 probe.")]
     [DefaultProperty("Configuration")]
-    public class NeuropixelsV1Device : ONIFrameReader<NeuropixelsV1DataFrame>
+    public class NeuropixelsV1Device : ONIFrameReader<NeuropixelsV1DataFrame, ushort>
     {
         enum Register
         {
@@ -46,7 +46,7 @@ namespace Bonsai.ONIX
             }
         }
 
-        protected override IObservable<NeuropixelsV1DataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<NeuropixelsV1DataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
 
             var data_block = new NeuropixelsV1DataBlock(BlockSize);

--- a/Bonsai.ONIX/ONIContextTask.cs
+++ b/Bonsai.ONIX/ONIContextTask.cs
@@ -18,7 +18,7 @@ namespace Bonsai.ONIX
         /// If the queue fills, frame reading will throttle, filling host memory instead of 
         /// userspace memory.
         /// </summary>
-        private const Int32 MaxQueuedFrames = 200000;
+        private const Int32 MaxQueuedFrames = 2000000;
         /// <summary>
         /// Timeout in ms for queue reads. This should not be critical as the 
         /// read operation will cancel if the task is stopped
@@ -59,10 +59,10 @@ namespace Bonsai.ONIX
         internal void Start()
         {
             ctx.Start(true);
-            TokenSource = new CancellationTokenSource(MaxQueuedFrames);
+            TokenSource = new CancellationTokenSource();
             CollectFramesToken = TokenSource.Token;
 
-            FrameQueue = new BlockingCollection<oni.Frame>();
+            FrameQueue = new BlockingCollection<oni.Frame>(MaxQueuedFrames);
 
             ReadFrames = Task.Factory.StartNew(() =>
             {

--- a/Bonsai.ONIX/ONIContextTask.cs
+++ b/Bonsai.ONIX/ONIContextTask.cs
@@ -79,9 +79,7 @@ namespace Bonsai.ONIX
                     }
                     catch (OperationCanceledException) 
                     {
-                        long dataSize = frame.DataSize;
-                        frame.Dispose();
-                        GC.RemoveMemoryPressure(dataSize);
+                        DisposeFrame(frame);
                     };
                 }
             },
@@ -125,9 +123,7 @@ namespace Bonsai.ONIX
             {
                 oni.Frame frame;
                 frame = FrameQueue.Take();
-                long dataSize = frame.DataSize;
-                frame.Dispose();
-                GC.RemoveMemoryPressure(dataSize);
+                DisposeFrame(frame);
             }
             FrameQueue?.Dispose();
             FrameQueue = null;
@@ -247,8 +243,13 @@ namespace Bonsai.ONIX
         void OnFrameReceived(FrameReceivedEventArgs e)
         {
             FrameReceived?.Invoke(this, e);
-            long dataSize = e.Frame.DataSize;
-            e.Frame.Dispose();
+            DisposeFrame(e.Frame);
+        }
+
+        void DisposeFrame(oni.Frame frame)
+        {
+            long dataSize = frame.DataSize;
+            frame.Dispose();
             GC.RemoveMemoryPressure(dataSize);
         }
 

--- a/Bonsai.ONIX/ONIFrameReader.cs
+++ b/Bonsai.ONIX/ONIFrameReader.cs
@@ -42,7 +42,7 @@ namespace Bonsai.ONIX
                     });
                 });
 
-            return Process(source.ObserveOn(Scheduler.Default.DisableOptimizations(typeof(ISchedulerLongRunning))));
+            return Process(source);
         }
 
         protected abstract IObservable<TResult> Process(IObservable<oni.Frame> source);

--- a/Bonsai.ONIX/ONIFrameReader.cs
+++ b/Bonsai.ONIX/ONIFrameReader.cs
@@ -9,13 +9,14 @@ namespace Bonsai.ONIX
     [Source]
     [Combinator(MethodName = "Generate")]
     [WorkflowElementCategory(ElementCategory.Source)]
-    public abstract class ONIFrameReader<TResult> : ONIDevice
+    public abstract class ONIFrameReader<TResult, TData> : ONIDevice
+        where TData : unmanaged
     {
         public ONIFrameReader(ONIXDevices.ID dev_id) : base(dev_id) { }
 
         public IObservable<TResult> Generate()
         {
-            var source = Observable.Create<oni.Frame>(async observer =>
+            var source = Observable.Create<RawDataFrame<TData>>(async observer =>
                 {
                     var cd = await ONIContextManager.ReserveOpenContextAsync(DeviceAddress.HardwareSlot);
 
@@ -29,7 +30,8 @@ namespace Bonsai.ONIX
                     {
                         if (e.Frame.DeviceAddress == DeviceAddress.Address)
                         {
-                            observer.OnNext(e.Frame);
+                            RawDataFrame<TData> frame = new RawDataFrame<TData>(e.Frame);
+                            observer.OnNext(frame);
                         }
                     };
 
@@ -45,6 +47,6 @@ namespace Bonsai.ONIX
             return Process(source);
         }
 
-        protected abstract IObservable<TResult> Process(IObservable<oni.Frame> source);
+        protected abstract IObservable<TResult> Process(IObservable<RawDataFrame<TData>> source);
     }
 }

--- a/Bonsai.ONIX/RHD2164Device.cs
+++ b/Bonsai.ONIX/RHD2164Device.cs
@@ -8,7 +8,7 @@ namespace Bonsai.ONIX
     // TODO: More abstract control over chip's registers?
 
     [Description("Acquires data from a single RHD2164 bioamplifier chip.")]
-    public class RHD2164Device : ONIFrameReader<RHDDataFrame>
+    public class RHD2164Device : ONIFrameReader<RHDDataFrame, ushort>
     {
         // see http://intantech.com/files/Intan_RHD2164_datasheet.pdf
         enum Register
@@ -43,7 +43,7 @@ namespace Bonsai.ONIX
 
         public RHD2164Device() : base(ONIXDevices.ID.RHD2164) { }
 
-        protected override IObservable<RHDDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<RHDDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             var data_block = new RHDDataBlock(64, BlockSize);
 

--- a/Bonsai.ONIX/RawDataFrame.cs
+++ b/Bonsai.ONIX/RawDataFrame.cs
@@ -1,18 +1,35 @@
-﻿using OpenCV.Net;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Bonsai.ONIX
 {
-    public class RawDataFrame : DataFrame
+    /// <summary>
+    /// Managed copy of <see cref="oni.Frame"/> with strongly-typed data array
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class RawDataFrame<T> where T : unmanaged
     {
+        public T[] sample;
+
         public RawDataFrame(oni.Frame frame)
-            : base(frame)
         {
-            var data = new ArraySegment<ushort>(sample, 4, sample.Length - 4);
-            Data = Mat.FromArray(data.ToArray(), sample.Length - 4, 1, Depth.U16, 1);
+            sample = frame.Data<T>();
+            //copy frame-specific properties
+            FrameClock = frame.Clock;
+            DeviceAddress = frame.DeviceAddress;
         }
 
-        public Mat Data { get; private set; }
+        public RawDataFrame(RawDataFrame<T> orig)
+        {
+            sample = orig.sample;
+        }
+
+        public ulong FrameClock { get; private set; }
+        public uint DeviceAddress { get; private set; }
+
     }
+
 }

--- a/Bonsai.ONIX/RawDevice.cs
+++ b/Bonsai.ONIX/RawDevice.cs
@@ -5,13 +5,13 @@ using System.Reactive.Linq;
 
 namespace Bonsai.ONIX
 {
-    public class RawDevice : ONIFrameReader<RawDataFrame>
+    public class RawDevice : ONIFrameReader<RawDeviceDataFrame, ushort>
     {
         public RawDevice() : base(ONIXDevices.ID.NULL) { }
 
-        protected override IObservable<RawDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<RawDeviceDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
-            return source.Select(f => { return new RawDataFrame(f); });
+            return source.Select(f => { return new RawDeviceDataFrame(f); });
         }
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/RawDeviceDataFrame.cs
+++ b/Bonsai.ONIX/RawDeviceDataFrame.cs
@@ -1,0 +1,18 @@
+﻿using OpenCV.Net;
+using System;
+using System.Linq;
+
+namespace Bonsai.ONIX
+{
+    public class RawDeviceDataFrame : DataFrame
+    {
+        public RawDeviceDataFrame(RawDataFrame<ushort> frame)
+            : base(frame)
+        {
+            var data = new ArraySegment<ushort>(frame.sample, 4, frame.sample.Length - 4);
+            Data = Mat.FromArray(data.ToArray(), frame.sample.Length - 4, 1, Depth.U16, 1);
+        }
+
+        public Mat Data { get; private set; }
+    }
+}

--- a/Bonsai.ONIX/TS4231V1DataFrame.cs
+++ b/Bonsai.ONIX/TS4231V1DataFrame.cs
@@ -2,13 +2,13 @@
 {
     public class TS4231V1DataFrame : DataFrame
     {
-        public TS4231V1DataFrame(oni.Frame frame)
+        public TS4231V1DataFrame(RawDataFrame<ushort> frame)
             : base(frame)
         {
             // Data
-            Index = sample[4];
-            PulseWidth = ((uint)sample[5] << 16) | ((uint)sample[6] << 0);
-            PulseType = (short)sample[7];
+            Index = frame.sample[4];
+            PulseWidth = ((uint)frame.sample[5] << 16) | ((uint)frame.sample[6] << 0);
+            PulseType = (short)frame.sample[7];
         }
 
         public ushort Index { get; private set; }

--- a/Bonsai.ONIX/TS4231V1Device.cs
+++ b/Bonsai.ONIX/TS4231V1Device.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Triad TS4231 optical to digital converter array for V1 SteamVR base stations.")]
-    public class TS4231V1Device : ONIFrameReader<TS4231V1DataFrame>
+    public class TS4231V1Device : ONIFrameReader<TS4231V1DataFrame, ushort>
     {
         enum Register
         {
@@ -16,7 +16,7 @@ namespace Bonsai.ONIX
 
         public TS4231V1Device() : base(ONIXDevices.ID.TS4231V1ARR) { }
 
-        protected override IObservable<TS4231V1DataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<TS4231V1DataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new TS4231V1DataFrame(f); });
         }

--- a/Bonsai.ONIX/TestDataFrame.cs
+++ b/Bonsai.ONIX/TestDataFrame.cs
@@ -2,9 +2,9 @@
 {
     public class TestDataFrame : DataFrame
     {
-        public TestDataFrame(oni.Frame frame) : base(frame)
+        public TestDataFrame(RawDataFrame<ushort> frame) : base(frame)
         {
-            Message = (sample[4] << 16) | (sample[5] << 0);
+            Message = (frame.sample[4] << 16) | (frame.sample[5] << 0);
         }
 
         public int Message { get; private set; }

--- a/Bonsai.ONIX/TestDevice.cs
+++ b/Bonsai.ONIX/TestDevice.cs
@@ -6,7 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("ONI Test device.")]
-    public class TestDevice : ONIFrameReader<TestDataFrame>
+    public class TestDevice : ONIFrameReader<TestDataFrame, ushort>
     {
         enum Register
         {
@@ -16,7 +16,7 @@ namespace Bonsai.ONIX
 
         public TestDevice() : base(ONIXDevices.ID.TEST) { }
 
-        protected override IObservable<TestDataFrame> Process(IObservable<oni.Frame> source)
+        protected override IObservable<TestDataFrame> Process(IObservable<RawDataFrame<ushort>> source)
         {
             return source.Select(f => { return new TestDataFrame(f); });
         }


### PR DESCRIPTION
This PR includes two main changes:

- Separates the unmanaged frame object from the managed, reactive context
- Keeps a separate task continuously reading frames from hardware

Extra comments:
- The queue used for sending read frames to the processing task has a fixed size, so in case processing were slower than the frame read rate, this will throttle. This might cause the host buffer memory to fill, but that is easier to diagnose that PC memory filling, which is not visible without a debugger. This won't work if there is another queue in the processing chain (for example, if work was dispatched into different threads by a scheduler)
-Since reading is now done on its own thread, ObserveOn operators have been removed for now.