### PR TITLE
Fix crash when externalizing device address property

### DIFF
--- a/Bonsai.ONIX.Design/ONIContextConfigurationEditorDialog.cs
+++ b/Bonsai.ONIX.Design/ONIContextConfigurationEditorDialog.cs
@@ -191,8 +191,6 @@ namespace Bonsai.ONIX.Design
                         // Hacky "back door" into ONIDeviceIndexTypeConverter's functionality
                         device.DeviceAddress = new ONIDeviceAddress { HardwareSlot = Configuration.Slot, Address = deviceIndex };
                         propertyGridSelecteDevice.SelectedObject = device;
-                        device.FrameClockHz = c.Context.AcquisitionClockHz;
-                        device.Hub = c.Context.GetHub((uint)device.DeviceAddress.Address);
                     }
                     else
                     {

--- a/Bonsai.ONIX.Design/StimulatorEditorDialog.cs
+++ b/Bonsai.ONIX.Design/StimulatorEditorDialog.cs
@@ -28,10 +28,6 @@ namespace Bonsai.ONIX.Design
 
                         // Bind to properties pane
                         propertyGridStimulator.SelectedObject = device;
-
-                        // Copy Device metadata
-                        device.FrameClockHz = c.Context.AcquisitionClockHz;
-                        device.Hub = c.Context.GetHub((uint)device.DeviceAddress.Address);
                     }
                     else
                     {

--- a/Bonsai.ONIX/AnalogIODevice.cs
+++ b/Bonsai.ONIX/AnalogIODevice.cs
@@ -44,6 +44,9 @@ namespace Bonsai.ONIX
                 .CombineLatest(source.Buffer(BlockSize), (s, block) => { return new AnalogInputDataFrame(block, s, DataType); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.BreakoutAnalogIO)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         // TODO: The order of data in the matrix is reverse of the channel index.
         // m[11] => channel 0, etc.
         protected override void Write(ONIContextTask ctx, Arr input)

--- a/Bonsai.ONIX/AnalogIODevice.cs
+++ b/Bonsai.ONIX/AnalogIODevice.cs
@@ -10,6 +10,7 @@ namespace Bonsai.ONIX
         "Optionally, sends data to the 16-bit analog outputs on the Open Ephys Host bpard, if those " +
         "channels are selected to be outputs. The output range is fixed to +/-10V. Usually these signals" +
         "are accessed via the ONIX breakout board.")]
+    [ONIXDeviceID(ONIXDevices.ID.BreakoutAnalogIO)]
     public class AnalogIODevice : ONIFrameReaderAndWriter<Arr, AnalogInputDataFrame, short>
     {
         enum Register
@@ -32,7 +33,7 @@ namespace Bonsai.ONIX
 
         private readonly float[] scale;
 
-        public AnalogIODevice() : base(ONIXDevices.ID.BreakoutAnalogIO)
+        public AnalogIODevice() 
         {
             scale = Enumerable.Repeat((float)0.000305, AnalogInputDataFrame.NumberOfChannels).ToArray();
         }
@@ -44,7 +45,6 @@ namespace Bonsai.ONIX
                 .CombineLatest(source.Buffer(BlockSize), (s, block) => { return new AnalogInputDataFrame(block, s, DataType); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.BreakoutAnalogIO)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         // TODO: The order of data in the matrix is reverse of the channel index.

--- a/Bonsai.ONIX/BNO055Device.cs
+++ b/Bonsai.ONIX/BNO055Device.cs
@@ -21,6 +21,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new BNO055DataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.BNO055)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the input data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/BNO055Device.cs
+++ b/Bonsai.ONIX/BNO055Device.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("BNO055 inertial measurement unit.")]
+    [ONIXDeviceID(ONIXDevices.ID.BNO055)]
     public class BNO055Device : ONIFrameReader<BNO055DataFrame, ushort>
     {
         enum Register
@@ -14,14 +15,13 @@ namespace Bonsai.ONIX
             MESSAGE,
         }
 
-        public BNO055Device() : base(ONIXDevices.ID.BNO055) { }
+        public BNO055Device()  { }
 
         protected override IObservable<BNO055DataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new BNO055DataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.BNO055)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/ClockOutputDevice.cs
+++ b/Bonsai.ONIX/ClockOutputDevice.cs
@@ -38,6 +38,9 @@ namespace Bonsai.ONIX
 
         public ClockOutputDevice() : base(ONIXDevices.ID.FMCClockOutput) { }
 
+        [ONIXDeviceID(ONIXDevices.ID.FMCClockInput)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Acquisition")]
         [Description("Enable or disable the clock output.")]
         public bool ClockEnabled

--- a/Bonsai.ONIX/ClockOutputDevice.cs
+++ b/Bonsai.ONIX/ClockOutputDevice.cs
@@ -6,6 +6,7 @@ namespace Bonsai.ONIX
     [Description("Controls the high performance output clock that is synchronized to the system " +
         "clock on the Open Ephys FMC Host. A boolean input can be used to toggle the Enable " +
         "register.")]
+    [ONIXDeviceID(ONIXDevices.ID.FMCClockInput)]
     public class ClockOutputDevice : ONISink<bool>
     {
         enum Register
@@ -36,9 +37,9 @@ namespace Bonsai.ONIX
             return 100.0 * h / (h + l);
         }
 
-        public ClockOutputDevice() : base(ONIXDevices.ID.FMCClockOutput) { }
+        public ClockOutputDevice() { }
 
-        [ONIXDeviceID(ONIXDevices.ID.FMCClockInput)]
+        
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Acquisition")]

--- a/Bonsai.ONIX/DS90UB9xDevice.cs
+++ b/Bonsai.ONIX/DS90UB9xDevice.cs
@@ -5,17 +5,18 @@ using System.Reactive.Linq;
 
 namespace Bonsai.ONIX
 {
+    [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
     public class DS90UB9xDevice : ONIFrameReader<RawDataFrame, ushort>
     {
         [Description("Provides access to raw data from a DS90UB9x deserializer.")]
-        public DS90UB9xDevice() : base(ONIXDevices.ID.DS90UB9X) { }
+        public DS90UB9xDevice()  { }
 
         protected override IObservable<RawDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new RawDataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
+        
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/DS90UB9xDevice.cs
+++ b/Bonsai.ONIX/DS90UB9xDevice.cs
@@ -15,6 +15,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new RawDataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/DigitalIODevice.cs
+++ b/Bonsai.ONIX/DigitalIODevice.cs
@@ -9,6 +9,7 @@ namespace Bonsai.ONIX
     [Description("Acquires digital data from, and sends digital data to, an ONIX " +
         "Breakout Board and controls the indication LED state. The least significant bits of " +
         "the integer input are used to determine the output port state.")]
+    [ONIXDeviceID(ONIXDevices.ID.BreakoutDigitalIO)]
     public class DigitalIODevice : ONIFrameReaderAndWriter<int, BreakoutDigitalInputDataFrame, ushort>
     {
         enum Register
@@ -18,14 +19,13 @@ namespace Bonsai.ONIX
             LEDLVL = 2, // 0-255 overall LED brightness value.
         }
 
-        public DigitalIODevice() : base(ONIXDevices.ID.BreakoutDigitalIO) { }
+        public DigitalIODevice()  { }
 
         protected override IObservable<BreakoutDigitalInputDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new BreakoutDigitalInputDataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.BreakoutDigitalIO)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         protected override void Write(ONIContextTask ctx, int input)

--- a/Bonsai.ONIX/DigitalIODevice.cs
+++ b/Bonsai.ONIX/DigitalIODevice.cs
@@ -25,6 +25,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new BreakoutDigitalInputDataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.BreakoutDigitalIO)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         protected override void Write(ONIContextTask ctx, int input)
         {
             ctx.Write((uint)DeviceAddress.Address, (uint)input);

--- a/Bonsai.ONIX/ElectricalStimulationDevice.cs
+++ b/Bonsai.ONIX/ElectricalStimulationDevice.cs
@@ -34,6 +34,10 @@ namespace Bonsai.ONIX
         // Setup context etc
         public ElectricalStimulationDevice() : base(ONIXDevices.ID.ElectricalStimulator) { }
 
+        [ONIXDeviceID(ONIXDevices.ID.ElectricalStimulator)]
+        [Editor("Bonsai.ONIX.Design.StimulatorEditor, Bonsai.ONIX.Design", typeof(UITypeEditor))]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         private uint CurrentK(double currentuA)
         {
             double k = 3000 / (Math.Pow(2, DACResolution) - 1);
@@ -309,13 +313,6 @@ namespace Bonsai.ONIX
             {
                 WriteRegister((int)Register.ENABLE, (uint)((bool)value ? 1 : 0));
             }
-        }
-
-        [Editor("Bonsai.ONIX.Design.StimulatorEditor, Bonsai.ONIX.Design", typeof(UITypeEditor))]
-        new public ONIDeviceAddress DeviceAddress
-        {
-            get => base.DeviceAddress;
-            set => base.DeviceAddress = value;
         }
 
         protected override void OnNext(ONIContextTask ctx, bool triggered)

--- a/Bonsai.ONIX/ElectricalStimulationDevice.cs
+++ b/Bonsai.ONIX/ElectricalStimulationDevice.cs
@@ -7,6 +7,7 @@ namespace Bonsai.ONIX
     [Description("Controls a single microstimulator circuit. A boolean input can be" +
         "used to trigger stimulation: True = Stimulation triggered, False = Stimulation untriggered.")]
     [DefaultProperty("DeviceAddress")]
+    [ONIXDeviceID(ONIXDevices.ID.ElectricalStimulator)]
     public sealed class ElectricalStimulationDevice : ONISink<bool>
     {
         enum Register
@@ -32,9 +33,9 @@ namespace Bonsai.ONIX
         }
 
         // Setup context etc
-        public ElectricalStimulationDevice() : base(ONIXDevices.ID.ElectricalStimulator) { }
+        public ElectricalStimulationDevice() { }
 
-        [ONIXDeviceID(ONIXDevices.ID.ElectricalStimulator)]
+        
         [Editor("Bonsai.ONIX.Design.StimulatorEditor, Bonsai.ONIX.Design", typeof(UITypeEditor))]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 

--- a/Bonsai.ONIX/HeadstagePortControlDevice.cs
+++ b/Bonsai.ONIX/HeadstagePortControlDevice.cs
@@ -27,6 +27,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new HeadstagePortControlFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.FMCLinkController)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/HeadstagePortControlDevice.cs
+++ b/Bonsai.ONIX/HeadstagePortControlDevice.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Controls a digital communication link to a remote headstage on the Open Ephys FMC Host.")]
+    [ONIXDeviceID(ONIXDevices.ID.FMCLinkController)]
     public class HeadstagePortControlDevice : ONIFrameReader<HeadstagePortControlFrame, ushort>
     {
         const double VLIM = 8.0;
@@ -20,14 +21,14 @@ namespace Bonsai.ONIX
             SAVELINKVOLTAGE = 4,
         }
 
-        public HeadstagePortControlDevice() : base(ONIXDevices.ID.FMCLinkController) { }
+        public HeadstagePortControlDevice() { }
 
         protected override IObservable<HeadstagePortControlFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new HeadstagePortControlFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.FMCLinkController)]
+        
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/HeartbeatDevice.cs
+++ b/Bonsai.ONIX/HeartbeatDevice.cs
@@ -8,6 +8,7 @@ namespace Bonsai.ONIX
     using HeartbeatDataFrame = U16DataFrame;
 
     [Description("Heartbeat device")]
+    [ONIXDeviceID(ONIXDevices.ID.Heartbeat)]
     public class HeartbeatDevice : ONIFrameReader<HeartbeatDataFrame, ushort>
     {
         enum Register
@@ -17,9 +18,8 @@ namespace Bonsai.ONIX
             CLK_HZ = 2, // The frequency parameter, CLK_HZ, used in the calculation of CLK_DIV
         }
 
-        public HeartbeatDevice() : base(ONIXDevices.ID.Heartbeat) { }
+        public HeartbeatDevice() { }
 
-        [ONIXDeviceID(ONIXDevices.ID.Heartbeat)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         protected override IObservable<HeartbeatDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)

--- a/Bonsai.ONIX/HeartbeatDevice.cs
+++ b/Bonsai.ONIX/HeartbeatDevice.cs
@@ -19,6 +19,9 @@ namespace Bonsai.ONIX
 
         public HeartbeatDevice() : base(ONIXDevices.ID.Heartbeat) { }
 
+        [ONIXDeviceID(ONIXDevices.ID.Heartbeat)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         protected override IObservable<HeartbeatDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new HeartbeatDataFrame(f); });

--- a/Bonsai.ONIX/LoadTestingBlockDevice.cs
+++ b/Bonsai.ONIX/LoadTestingBlockDevice.cs
@@ -33,6 +33,9 @@ namespace Bonsai.ONIX
                 .Select(block => { return new LoadTestingBlockDataFrame(block, (int)FrameWords); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Range(1, 10000)]
         [Description("The number of frames making up a single data block that is propagated in the observable sequence.")]

--- a/Bonsai.ONIX/LoadTestingBlockDevice.cs
+++ b/Bonsai.ONIX/LoadTestingBlockDevice.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Variable load testing device, block version")]
+    [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
     public class LoadTestingBlockDevice : ONIFrameReader<LoadTestingBlockDataFrame, ushort>
     {
         enum Register
@@ -24,7 +25,7 @@ namespace Bonsai.ONIX
 
 
         }
-        public LoadTestingBlockDevice() : base(ONIXDevices.ID.LoadTest) { }
+        public LoadTestingBlockDevice() { }
 
         protected override IObservable<LoadTestingBlockDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -33,7 +34,6 @@ namespace Bonsai.ONIX
                 .Select(block => { return new LoadTestingBlockDataFrame(block, (int)FrameWords); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/LoadTestingDevice.cs
+++ b/Bonsai.ONIX/LoadTestingDevice.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Variable load testing device and latency tester.")]
+    [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
     public class LoadTestingDevice : ONIFrameReaderAndWriter<ulong, LoadTestingDataFrame, ushort>
     {
         private uint[] writeArray;
@@ -26,14 +27,13 @@ namespace Bonsai.ONIX
                               // testing loop latency. This value must be at least 2.
         }
 
-        public LoadTestingDevice() : base(ONIXDevices.ID.LoadTest) { }
+        public LoadTestingDevice() { }
 
         protected override IObservable<LoadTestingDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new LoadTestingDataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         protected override void Write(ONIContextTask ctx, ulong input)

--- a/Bonsai.ONIX/LoadTestingDevice.cs
+++ b/Bonsai.ONIX/LoadTestingDevice.cs
@@ -33,6 +33,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new LoadTestingDataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.LoadTest)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         protected override void Write(ONIContextTask ctx, ulong input)
         {
             writeArray[0] = (uint)(input & uint.MaxValue);

--- a/Bonsai.ONIX/MemoryUsageDevice.cs
+++ b/Bonsai.ONIX/MemoryUsageDevice.cs
@@ -24,6 +24,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new MemoryUsageDataFrame(f, total_words); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.MemoryUsage)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/MemoryUsageDevice.cs
+++ b/Bonsai.ONIX/MemoryUsageDevice.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Memory usage monitoring device")]
+    [ONIXDeviceID(ONIXDevices.ID.MemoryUsage)]
     public class MemoryUsageDevice : ONIFrameReader<MemoryUsageDataFrame, ushort>
     {
         enum Register
@@ -16,7 +17,7 @@ namespace Bonsai.ONIX
             TOTAL_MEM = 3, //Total memory in 32bit words
         }
 
-        public MemoryUsageDevice() : base(ONIXDevices.ID.MemoryUsage) { }
+        public MemoryUsageDevice() { }
 
         protected override IObservable<MemoryUsageDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -24,7 +25,6 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new MemoryUsageDataFrame(f, total_words); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.MemoryUsage)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/NeuropixelsV1Configuration.cs
+++ b/Bonsai.ONIX/NeuropixelsV1Configuration.cs
@@ -34,6 +34,8 @@ namespace Bonsai.ONIX
         public bool RefreshNeeded { get; set; } = true;
 
         private ONIDeviceAddress dev_address = new ONIDeviceAddress();
+        
+        [ONIXDeviceID(ONIXDevices.ID.NeuropixelsV1)]
         public ONIDeviceAddress DeviceAddress
         {
             get

--- a/Bonsai.ONIX/NeuropixelsV1Configuration.cs
+++ b/Bonsai.ONIX/NeuropixelsV1Configuration.cs
@@ -35,7 +35,6 @@ namespace Bonsai.ONIX
 
         private ONIDeviceAddress dev_address = new ONIDeviceAddress();
         
-        [ONIXDeviceID(ONIXDevices.ID.NeuropixelsV1)]
         public ONIDeviceAddress DeviceAddress
         {
             get

--- a/Bonsai.ONIX/NeuropixelsV1Device.cs
+++ b/Bonsai.ONIX/NeuropixelsV1Device.cs
@@ -63,6 +63,7 @@ namespace Bonsai.ONIX
         [Category("ONI Configuration")]
         [Description("The full device hardware address consisting of a hardware slot and device table index.")]
         [TypeConverter(typeof(ONIDeviceAddressTypeConverter))]
+        [ONIXDeviceID(ONIXDevices.ID.NeuropixelsV1)]
         public override ONIDeviceAddress DeviceAddress
         {
             get { return Configuration.DeviceAddress; }

--- a/Bonsai.ONIX/NeuropixelsV1Device.cs
+++ b/Bonsai.ONIX/NeuropixelsV1Device.cs
@@ -9,9 +9,10 @@ namespace Bonsai.ONIX
 {
     [Description("Acquires a stream of \"ultra-frames\" from a single Neuropixels v1.0 probe.")]
     [DefaultProperty("Configuration")]
+    [ONIXDeviceID(ONIXDevices.ID.NeuropixelsV1)]
     public class NeuropixelsV1Device : ONIFrameReader<NeuropixelsV1DataFrame, ushort>
     {
-        public NeuropixelsV1Device() : base(ONIXDevices.ID.NeuropixelsV1) { }
+        public NeuropixelsV1Device() { }
 
         protected override IObservable<NeuropixelsV1DataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -63,7 +64,6 @@ namespace Bonsai.ONIX
         [Category("ONI Configuration")]
         [Description("The full device hardware address consisting of a hardware slot and device table index.")]
         [TypeConverter(typeof(ONIDeviceAddressTypeConverter))]
-        [ONIXDeviceID(ONIXDevices.ID.NeuropixelsV1)]
         public override ONIDeviceAddress DeviceAddress
         {
             get { return Configuration.DeviceAddress; }

--- a/Bonsai.ONIX/ONIDevice.cs
+++ b/Bonsai.ONIX/ONIDevice.cs
@@ -14,24 +14,62 @@ namespace Bonsai.ONIX
         [Description("The full device hardware address consisting of a hardware slot and device table index.")]
         [TypeConverter(typeof(ONIDeviceAddressTypeConverter))]
         [Editor("Bonsai.ONIX.Design.DocumentationLink, Bonsai.ONIX.Design", typeof(UITypeEditor))]
-        public virtual ONIDeviceAddress DeviceAddress
-        {
-            get { return deviceAddress; }
-            set { deviceAddress = value; OnDeviceAddressUpdate(); }
-        }
+        public abstract ONIDeviceAddress DeviceAddress { get; set; }
+
+        //Keep a local copy until address changes to avoid accessing the register interface a million times for already-known information
+        private oni.Hub deviceHub = null;
+        private ONIDeviceAddress oldAddressHub = null;
+        private ONIDeviceAddress oldAddressHz = null;
+        private double? contextHz = null;
 
         [Category("ONI Configuration")]
         [Description("The hub that this device belongs to.")]
         [TypeConverter(typeof(ExpandableObjectConverter))]
         [EditorBrowsable(EditorBrowsableState.Always)]
-        [Externalizable(true)]
-        public oni.Hub Hub { get; set; }
+        [Externalizable(false)]
+        public oni.Hub Hub
+        {
+            get
+            {
+                if (DeviceAddress.Valid)
+                {
+                    if (deviceHub == null || oldAddressHub == null || oldAddressHub != DeviceAddress)
+                    {
+                        using (var c = ONIContextManager.ReserveContext(DeviceAddress.HardwareSlot))
+                        {
+                            deviceHub = c.Context.GetHub((uint)DeviceAddress.Address);
+                        }
+                        oldAddressHub = DeviceAddress;
+                    }
+                    return deviceHub;
+                }
+                else return null;
+            }
+        }
 
         [Category("ONI Configuration")]
         [Description("The rate of the host frame clock counter (Hz).")]
-        [Externalizable(true)]
+        [Externalizable(false)]
         [ReadOnly(true)]
-        public double? FrameClockHz { get; set; }
+        public double? FrameClockHz
+        {
+            get
+            {
+                if (DeviceAddress.Valid)
+                {
+                    if (contextHz == null || oldAddressHz == null || oldAddressHz != DeviceAddress)
+                    {
+                        using (var c = ONIContextManager.ReserveContext(DeviceAddress.HardwareSlot))
+                        {
+                            contextHz = c.Context.AcquisitionClockHz;
+                        }
+                        oldAddressHz = DeviceAddress;
+                    }
+                    return contextHz;
+                }
+                else return null;
+            }
+        }
 
         public ONIDevice(ONIXDevices.ID deviceID)
         {

--- a/Bonsai.ONIX/ONIDevice.cs
+++ b/Bonsai.ONIX/ONIDevice.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Drawing.Design;
+using System.Linq;
 
 namespace Bonsai.ONIX
 {
@@ -71,9 +72,10 @@ namespace Bonsai.ONIX
             }
         }
 
-        public ONIDevice(ONIXDevices.ID deviceID)
+        public ONIDevice()
         {
-            ID = deviceID;
+            var devID = this.GetType().GetCustomAttributes(typeof(ONIXDeviceIDAttribute), true).FirstOrDefault() as ONIXDeviceIDAttribute;
+            ID = devID == null ? ONIXDevices.ID.Null : devID.deviceID;
             deviceAddress = new ONIDeviceAddress();
         }
 

--- a/Bonsai.ONIX/ONIDeviceAddressTypeConverter.cs
+++ b/Bonsai.ONIX/ONIDeviceAddressTypeConverter.cs
@@ -11,8 +11,6 @@ namespace Bonsai.ONIX
     // TODO: This thing is a true nightmare, but its OK for now
     class ONIDeviceAddressTypeConverter : TypeConverter
     {
-        Dictionary<string, Tuple<uint, oni.Hub>> hubs;
-
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
@@ -24,15 +22,11 @@ namespace Bonsai.ONIX
             object result = null;
 
             var string_value = value as string;
-            var device = (ONIDevice)context.Instance;
-            var clks_good = hubs.TryGetValue(string_value, out var clks);
 
-            if (!string.IsNullOrEmpty(string_value) && device != null && clks_good)
+
+            if (!string.IsNullOrEmpty(string_value)) 
             {
                 var matches = ReverseStringFormat("({0},{1}): {2}", string_value);
-
-                device.FrameClockHz = clks.Item1;
-                device.Hub = clks.Item2;
 
                 result = new ONIDeviceAddress
                 {
@@ -78,15 +72,12 @@ namespace Bonsai.ONIX
                                      .ToList();
 
                     // This device
-                    var device = (ONIDevice)context.Instance;
-                    if (device == null)
-                    {
-                        return base.GetStandardValues(context);
-                    }
+                    var deviceattribute = ((ONIXDeviceIDAttribute)context.PropertyDescriptor.Attributes[typeof(ONIXDeviceIDAttribute)]);
+                    ONIXDevices.ID deviceID = deviceattribute == null ? ONIXDevices.ID.Null : deviceattribute.deviceID;
+
 
                     // To fill after inspecting hardware
                     var device_addrs = new List<ONIDeviceAddress>();
-                    hubs = new Dictionary<string, Tuple<uint, oni.Hub>>();
 
                     foreach (var hw in hw_slots)
                     {
@@ -96,7 +87,11 @@ namespace Bonsai.ONIX
                             {
                                 // Find valid device indices
                                 var dev_matches = c.Context.DeviceTable
-                                    .Where(dev => dev.Value.ID == (uint)device.ID)
+                                    //.Where(dev => dev.Value.ID == (uint)device.ID)
+                                    .Where(dev => {
+                                        if (deviceID == ONIXDevices.ID.Null) return (dev.Value.ID != (uint)ONIXDevices.ID.Null);
+                                        else return (dev.Value.ID == (uint)deviceID);
+                                    })
                                     .Select(x =>
                                     {
                                         var d = new ONIDeviceAddress
@@ -109,11 +104,7 @@ namespace Bonsai.ONIX
 
                                 device_addrs = device_addrs.Concat(dev_matches).ToList();
 
-                                foreach (var d in dev_matches)
-                                {
-                                    hubs.Add(d.ToString(),
-                                        new Tuple<uint, oni.Hub>(c.Context.AcquisitionClockHz, c.Context.GetHub((uint)d.Address)));
-                                }
+                                
                             }
                         }
                         catch (InvalidProgramException) // Bad context initialization

--- a/Bonsai.ONIX/ONIDeviceAddressTypeConverter.cs
+++ b/Bonsai.ONIX/ONIDeviceAddressTypeConverter.cs
@@ -72,7 +72,7 @@ namespace Bonsai.ONIX
                                      .ToList();
 
                     // This device
-                    var deviceattribute = ((ONIXDeviceIDAttribute)context.PropertyDescriptor.Attributes[typeof(ONIXDeviceIDAttribute)]);
+                    var deviceattribute = context.PropertyDescriptor.ComponentType.GetCustomAttributes(typeof(ONIXDeviceIDAttribute), true).FirstOrDefault() as ONIXDeviceIDAttribute;
                     ONIXDevices.ID deviceID = deviceattribute == null ? ONIXDevices.ID.Null : deviceattribute.deviceID;
 
 

--- a/Bonsai.ONIX/ONIFrameReader.cs
+++ b/Bonsai.ONIX/ONIFrameReader.cs
@@ -9,7 +9,7 @@ namespace Bonsai.ONIX
     [WorkflowElementCategory(ElementCategory.Source)]
     public abstract class ONIFrameReader<TResult, TData> : ONIDevice where TData : unmanaged
     {
-        public ONIFrameReader(ONIXDevices.ID deviceId) : base(deviceId) { }
+        public ONIFrameReader() : base() { }
 
         public IObservable<TResult> Generate()
         {

--- a/Bonsai.ONIX/ONIFrameReaderAndWriter.cs
+++ b/Bonsai.ONIX/ONIFrameReaderAndWriter.cs
@@ -9,7 +9,7 @@ namespace Bonsai.ONIX
     [WorkflowElementCategory(ElementCategory.Source)]
     public abstract class ONIFrameReaderAndWriter<TSource, TResult, TData> : ONIDevice where TData : unmanaged
     {
-        public ONIFrameReaderAndWriter(ONIXDevices.ID dev_id) : base(dev_id) { }
+        public ONIFrameReaderAndWriter() : base() { }
 
         public IObservable<TResult> Generate()
         {

--- a/Bonsai.ONIX/ONISink.cs
+++ b/Bonsai.ONIX/ONISink.cs
@@ -9,7 +9,7 @@ namespace Bonsai.ONIX
     [WorkflowElementCategory(ElementCategory.Sink)]
     public abstract class ONISink<TSource> : ONIDevice
     {
-        public ONISink(ONIXDevices.ID deviceID) : base(deviceID) { }
+        public ONISink() : base() { }
 
         public IObservable<TSource> Process(IObservable<TSource> source)
         {

--- a/Bonsai.ONIX/ONIXDeviceIDAttribute.cs
+++ b/Bonsai.ONIX/ONIXDeviceIDAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bonsai.ONIX
+{
+    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    class ONIXDeviceIDAttribute : System.Attribute
+    {
+        public ONIXDevices.ID deviceID;
+
+        public ONIXDeviceIDAttribute(ONIXDevices.ID id)
+        {
+            deviceID = id;
+        }
+    }
+}

--- a/Bonsai.ONIX/ONIXDeviceIDAttribute.cs
+++ b/Bonsai.ONIX/ONIXDeviceIDAttribute.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Bonsai.ONIX
 {
-    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     class ONIXDeviceIDAttribute : System.Attribute
     {
         public ONIXDevices.ID deviceID;

--- a/Bonsai.ONIX/OpticalStimulationDevice.cs
+++ b/Bonsai.ONIX/OpticalStimulationDevice.cs
@@ -31,6 +31,7 @@ namespace Bonsai.ONIX
         // Setup context etc
         public OpticalStimulationDevice() : base(ONIXDevices.ID.OpticalStimulator) { }
 
+        
         // Fit from Fig. 10 of CAT4016 datasheet
         // x = (y/a)^(1/b)
         // a = 3.833e+05
@@ -302,12 +303,8 @@ namespace Bonsai.ONIX
         [Description("The full device hardware address consisting of a hardware slot and device table index.")]
         [Editor("Bonsai.ONIX.Design.StimulatorEditor, Bonsai.ONIX.Design", typeof(UITypeEditor))]
         [TypeConverter(typeof(ONIDeviceAddressTypeConverter))]
-        public new ONIDeviceAddress DeviceAddress
-        {
-            get => base.DeviceAddress;
-            set => base.DeviceAddress = value;
-        }
-
+        [ONIXDeviceID(ONIXDevices.ID.OpticalStimulator)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
         protected override void OnNext(ONIContextTask ctx, bool triggered)
         {
             WriteRegister((int)Register.TRIGGER, (uint)(triggered ? 1 : 0));

--- a/Bonsai.ONIX/OpticalStimulationDevice.cs
+++ b/Bonsai.ONIX/OpticalStimulationDevice.cs
@@ -7,6 +7,7 @@ namespace Bonsai.ONIX
     [Description("Controls a dual channel optical (LED or Laser Diode) stimulator. A boolean input can be" +
         "used to trigger stimulation: True = Stimulation triggered, False = Stimulation untriggered.")]
     [DefaultProperty("DeviceAddress")]
+    [ONIXDeviceID(ONIXDevices.ID.OpticalStimulator)]
     public sealed class OpticalStimulationDevice : ONISink<bool>
     {
         enum Register
@@ -29,7 +30,7 @@ namespace Bonsai.ONIX
         }
 
         // Setup context etc
-        public OpticalStimulationDevice() : base(ONIXDevices.ID.OpticalStimulator) { }
+        public OpticalStimulationDevice() { }
 
         
         // Fit from Fig. 10 of CAT4016 datasheet
@@ -303,7 +304,6 @@ namespace Bonsai.ONIX
         [Description("The full device hardware address consisting of a hardware slot and device table index.")]
         [Editor("Bonsai.ONIX.Design.StimulatorEditor, Bonsai.ONIX.Design", typeof(UITypeEditor))]
         [TypeConverter(typeof(ONIDeviceAddressTypeConverter))]
-        [ONIXDeviceID(ONIXDevices.ID.OpticalStimulator)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
         protected override void OnNext(ONIContextTask ctx, bool triggered)
         {

--- a/Bonsai.ONIX/RHD2164Device.cs
+++ b/Bonsai.ONIX/RHD2164Device.cs
@@ -51,6 +51,9 @@ namespace Bonsai.ONIX
                 .Select(block => { return new RHD2164DataFrame(block, ephysDataFormat, auxDataFormat); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.RHD2164)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/RHD2164Device.cs
+++ b/Bonsai.ONIX/RHD2164Device.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Acquires data from a single RHD2164 bioamplifier chip. Ephys data is acquired at 30 kHz/channel.")]
+    [ONIXDeviceID(ONIXDevices.ID.RHD2164)]
     public class RHD2164Device : ONIFrameReader<RHD2164DataFrame, ushort>
     {
         // see http://intantech.com/files/Intan_RHD2164_datasheet.pdf
@@ -39,7 +40,7 @@ namespace Bonsai.ONIX
             ENABLE = 0x00008000
         }
 
-        public RHD2164Device() : base(ONIXDevices.ID.RHD2164) { }
+        public RHD2164Device() { }
 
         protected override IObservable<RHD2164DataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -51,7 +52,6 @@ namespace Bonsai.ONIX
                 .Select(block => { return new RHD2164DataFrame(block, ephysDataFormat, auxDataFormat); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.RHD2164)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/RawDevice.cs
+++ b/Bonsai.ONIX/RawDevice.cs
@@ -5,9 +5,10 @@ using System.Reactive.Linq;
 
 namespace Bonsai.ONIX
 {
+    [ONIXDeviceID(ONIXDevices.ID.Null)]
     public class RawDevice : ONIFrameReader<RawDataFrame, ushort>
     {
-        public RawDevice() : base(ONIXDevices.ID.Null) { }
+        public RawDevice() { }
 
         protected override IObservable<RawDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -16,7 +17,6 @@ namespace Bonsai.ONIX
 
         private ONIDeviceAddress deviceAddress = new ONIDeviceAddress();
 
-        [ONIXDeviceID(ONIXDevices.ID.Null)]
         public override ONIDeviceAddress DeviceAddress
         {
             get

--- a/Bonsai.ONIX/RawDevice.cs
+++ b/Bonsai.ONIX/RawDevice.cs
@@ -14,26 +14,41 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new RawDataFrame(f); });
         }
 
-        [Category("Configuration")]
-        [Description("Device type to acquire raw data frames from.")]
-        public ONIXDevices.ID DeviceType
+        private ONIDeviceAddress deviceAddress = new ONIDeviceAddress();
+
+        [ONIXDeviceID(ONIXDevices.ID.Null)]
+        public override ONIDeviceAddress DeviceAddress
         {
             get
             {
-                return ID;
+                return deviceAddress;
             }
             set
             {
-                if (ID != value)
+                deviceAddress = value;
+                RegisterIndex = 0;
+                if (deviceAddress.Valid)
                 {
-                    ID = value;
-                    DeviceAddress = null;
-                    FrameClockHz = null;
-                    Hub = null;
-                    RegisterIndex = 0;
+                    using (var c = ONIContextManager.ReserveContext(deviceAddress.HardwareSlot))
+                    {
+
+                        ID = (ONIXDevices.ID)c.Context.DeviceTable[(uint)deviceAddress.Address].ID;
+                    }
                 }
             }
-        }
+        } 
+
+        [Category("Configuration")]
+        [Description("Device type to acquire raw data frames from.")]
+        [Externalizable(false)]
+        [ReadOnly(true)]
+            public ONIXDevices.ID DeviceType
+            {
+                get
+                {
+                    return ID;
+                }
+            }
 
         uint registerIndex;
         [Category("Acquisition")]

--- a/Bonsai.ONIX/TS4231V1Device.cs
+++ b/Bonsai.ONIX/TS4231V1Device.cs
@@ -21,6 +21,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new TS4231V1DataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.TS4231V1Array)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/TS4231V1Device.cs
+++ b/Bonsai.ONIX/TS4231V1Device.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("Triad TS4231 optical to digital converter array for V1 SteamVR base stations.")]
+    [ONIXDeviceID(ONIXDevices.ID.TS4231V1Array)]
     public class TS4231V1Device : ONIFrameReader<TS4231V1DataFrame, ushort>
     {
         enum Register
@@ -14,14 +15,13 @@ namespace Bonsai.ONIX
             ENVMARGIN,
         }
 
-        public TS4231V1Device() : base(ONIXDevices.ID.TS4231V1Array) { }
+        public TS4231V1Device() { }
 
         protected override IObservable<TS4231V1DataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new TS4231V1DataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.TS4231V1Array)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/TestDevice.cs
+++ b/Bonsai.ONIX/TestDevice.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 namespace Bonsai.ONIX
 {
     [Description("ONI Test device.")]
+    [ONIXDeviceID(ONIXDevices.ID.Test)]
     public class TestDevice : ONIFrameReader<TestDataFrame, ushort>
     {
         enum Register
@@ -14,14 +15,13 @@ namespace Bonsai.ONIX
             MESSAGE,
         }
 
-        public TestDevice() : base(ONIXDevices.ID.Test) { }
+        public TestDevice() { }
 
         protected override IObservable<TestDataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
             return source.Select(f => { return new TestDataFrame(f); });
         }
 
-        [ONIXDeviceID(ONIXDevices.ID.Test)]
         public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
 
         [Category("Configuration")]

--- a/Bonsai.ONIX/TestDevice.cs
+++ b/Bonsai.ONIX/TestDevice.cs
@@ -21,6 +21,9 @@ namespace Bonsai.ONIX
             return source.Select(f => { return new TestDataFrame(f); });
         }
 
+        [ONIXDeviceID(ONIXDevices.ID.Test)]
+        public override ONIDeviceAddress DeviceAddress { get; set; } = new ONIDeviceAddress();
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream

--- a/Bonsai.ONIX/UCLAMiniscopeV3Device.cs
+++ b/Bonsai.ONIX/UCLAMiniscopeV3Device.cs
@@ -6,11 +6,12 @@ using System.Reactive.Linq;
 
 namespace Bonsai.ONIX
 {
+    [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
     public class UCLAMiniscopeV3Device : ONIFrameReader<UCLAMiniscopeV3DataFrame, ushort>
     {
 
         [Description("Acquire data from UCLA Miniscope V3.")]
-        public UCLAMiniscopeV3Device() : base(ONIXDevices.ID.DS90UB9X) { }
+        public UCLAMiniscopeV3Device()  { }
 
         protected override IObservable<UCLAMiniscopeV3DataFrame> Process(IObservable<ONIManagedFrame<ushort>> source)
         {
@@ -21,7 +22,6 @@ namespace Bonsai.ONIX
         }
 
         private ONIDeviceAddress deviceAddress;
-        [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
         public override ONIDeviceAddress DeviceAddress
         {
             get { return deviceAddress; }

--- a/Bonsai.ONIX/UCLAMiniscopeV3Device.cs
+++ b/Bonsai.ONIX/UCLAMiniscopeV3Device.cs
@@ -20,6 +20,14 @@ namespace Bonsai.ONIX
                 .Select(block => { return new UCLAMiniscopeV3DataFrame(block); });
         }
 
+        private ONIDeviceAddress deviceAddress;
+        [ONIXDeviceID(ONIXDevices.ID.DS90UB9X)]
+        public override ONIDeviceAddress DeviceAddress
+        {
+            get { return deviceAddress; }
+            set { deviceAddress = value; OnDeviceAddressUpdate(); }
+        }
+
         [Category("Configuration")]
         [Description("Enable the device data stream.")]
         public bool EnableStream


### PR DESCRIPTION
- DeviceAddress is now abstract and needs to be implemented in each
device
- A custom attribute is set for DeviceAddress allowing the Bonsai editor
to know which addresses to look for
- ID.Null or no attribute will list all addresses
- Hub and FrameClock info now gets filled by ONIDevice
- Raw device does no longer accept filtering addresses by device type.
Instead it will list all addresses and DeviceType property will show
which kind of device is